### PR TITLE
feat: less strict datadog and prometheus-client requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "snyk-metrics"
-version = "0.0.5"
+version = "0.0.6"
 description = "Python library to interact transparently with Prometheus, Pushgateway and Dogstatsd."
 authors = ["Snyk Security R&D <security-engineering@snyk.io>"]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,8 @@ include = ["LICENSE"]
 
 [tool.poetry.dependencies]
 python = "^3.7"
-datadog = "^0.43.0"
-prometheus-client = "^0.12.0"
+datadog = ">=0.43.0 <1.0.0"
+prometheus-client = ">=0.12.0 <1.0.0"
 
 [tool.poetry.dev-dependencies]
 black = "^22.1"


### PR DESCRIPTION
seems like major versions with 0.x.x are treated specially in semver and even minor releases are treated as breaking changes.

so even though ^1.0.0 is equivalent to >=1.0.0 <2.0.0 with ^0.x.x this turns to >=0.x.x <0.x+1.x